### PR TITLE
Add support for new SLF4J logger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.18-pre5"
+version = "1.4+22w03a"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json";
@@ -28,16 +28,15 @@ processResources {
 dependencies {
     minecraft "com.mojang:minecraft:1.18-pre5"
     mappings "net.fabricmc:yarn:1.18-pre5+build.4:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.12.5"
+    modImplementation "net.fabricmc:fabric-loader:0.12.12"
 }
 
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 // if it is present.
 // If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+java {
+    withSourcesJar()
 }
 
 jar {

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
@@ -24,20 +24,39 @@ public abstract class ReloadableResourceManagerImplMixin implements ReloadableRe
     @Shadow
     public abstract void addPack(ResourcePack resourcePack);
 
+    // Compatibility with 22w03a+ using slf4j logger instead of log4j
     @Inject(
             method = "reload",
             at = @At(
                     value = "INVOKE",
-                    target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
+                    target = "Lorg/slf4j/Logger;isDebugEnabled()Z",
                     shift = At.Shift.BEFORE
-            )
+            ),
+            require = 0
     )
     private void onPostReload(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
     {
         if (this.type != ResourceType.CLIENT_RESOURCES)
             return;
 
-        System.out.println("Inject generated resource packs.");
+        this.addPack(new CTResourcePack());
+    }
+
+    // Compatibility with 1.18.1 and below using log4j
+    @Inject(
+            method = "reload",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
+                    shift = At.Shift.BEFORE
+            ),
+            require = 0
+    )
+    private void onPostReloadLegacy(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
+    {
+        if (this.type != ResourceType.CLIENT_RESOURCES)
+            return;
+
         this.addPack(new CTResourcePack());
     }
 }


### PR DESCRIPTION
This uses the same technique that [Fabric API](https://github.com/FabricMC/fabric/commit/e66b59e98c4fc80778b077da360be59d99c03098) used for compat across versions - two injects, one targeted at slf4j and one at log4j, neither of which are required.
I have tested this against 1.18.1 and 22w03a. Both work well, and it should work back to the oldest version supported (1.18-pre5) :)
I also removed the debug println, as it is not necessary.