### PR TITLE
Make CowdinTranslateParameters lazy and DownloadTask use inputs

### DIFF
--- a/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/CrowdinTranslateParameters.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/CrowdinTranslateParameters.java
@@ -1,40 +1,17 @@
 package de.guntram.mcmod.crowdintranslate.GradlePlugin;
 
-public class CrowdinTranslateParameters {
-    String crowdinProjectName;
-    String minecraftProjectName;
-    String jsonSourceName;
-    boolean verbose;
-    
+import org.gradle.api.provider.Property;
+
+public abstract class CrowdinTranslateParameters {
     public void setCrowdinProjectname(String s) {
-        crowdinProjectName = s;
+        getCrowdinProjectName().set(s);
     }
-    
-    public String getCrowdinProjectName() {
-        return crowdinProjectName;
-    }
-    
-    public void setMinecraftProjectName(String s) {
-        minecraftProjectName = s;
-    }
-    
-    public String getMinecraftProjectName() {
-        return minecraftProjectName;
-    }
-    
-    public void setJsonSourceName(String s) {
-        jsonSourceName = s;
-    }
-    
-    public String getJsonSourceName() {
-        return jsonSourceName;
-    }
-    
-    public void setVerbose(boolean b) {
-        verbose = b;
-    }
-    
-    public boolean getVerbose() {
-        return verbose;
-    }
+
+    public abstract Property<String> getCrowdinProjectName();
+
+    public abstract Property<String> getMinecraftProjectName();
+
+    public abstract Property<String> getJsonSourceName();
+
+    public abstract Property<Boolean> getVerbose();
 }

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/CrowdinTranslatePlugin.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/CrowdinTranslatePlugin.java
@@ -7,20 +7,25 @@ package de.guntram.mcmod.crowdintranslate.GradlePlugin;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
 
 /**
  *
  * @author gbl
  */
 public class CrowdinTranslatePlugin implements Plugin<Project> {
-
-    public static CrowdinTranslateParameters parameters;
-
     @Override
     public void apply(Project project) {
-        
-        parameters = project.getExtensions()
+        final CrowdinTranslateParameters parameters = project.getExtensions()
                 .create("crowdintranslate", CrowdinTranslateParameters.class);
-        project.getTasks().create("downloadTranslations", DownloadTask.class);
+        parameters.getVerbose().convention(false);
+
+        project.getTasks().register("downloadTranslations", DownloadTask.class).configure(task -> {
+            task.getCrowdinProjectName().set(parameters.getCrowdinProjectName());
+            task.getMinecraftProjectName().set(parameters.getMinecraftProjectName());
+            task.getJsonSourceName().set(parameters.getJsonSourceName());
+            task.getVerbose().set(parameters.getVerbose());
+        });
     }
 }

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/DownloadTask.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/DownloadTask.java
@@ -2,26 +2,41 @@ package de.guntram.mcmod.crowdintranslate.GradlePlugin;
 
 import de.guntram.mcmod.crowdintranslate.CrowdinTranslate;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 
-public class DownloadTask extends DefaultTask {
+public abstract class DownloadTask extends DefaultTask {
+    @Input
+    @Optional
+    public abstract Property<String> getCrowdinProjectName();
+
+    @Input
+    public abstract Property<String> getMinecraftProjectName();
+
+    @Input
+    public abstract Property<String> getJsonSourceName();
+
+    @Input
+    public abstract Property<Boolean> getVerbose();
+
     @TaskAction
     public void action() {
-        CrowdinTranslateParameters parms = CrowdinTranslatePlugin.parameters;
-        if (parms.getCrowdinProjectName() == null) {
+        if (!getCrowdinProjectName().isPresent()) {
             System.err.println("No crowdin project name given, nothing downloaded");
             return;
         }
-        String[] args = new String[ (parms.getVerbose().get() ? 4 : 3) ];
+        String[] args = new String[ (getVerbose().get() ? 4 : 3) ];
         int argc = 0;
-        if (parms.getVerbose().get()) {
+        if (getVerbose().get()) {
             args[argc++] = "-v";
         }
-        String cpn = parms.getCrowdinProjectName().get();
-        String mpn = parms.getMinecraftProjectName().get();
+        String cpn = getCrowdinProjectName().get();
+        String mpn = getMinecraftProjectName().get();
         args[argc++] = cpn;
         args[argc++] = (mpn == null ? cpn : mpn);
-        args[argc++] = parms.getJsonSourceName().get();
+        args[argc++] = getJsonSourceName().get();
 
         CrowdinTranslate.main(args);
         this.setDidWork(true);

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/DownloadTask.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/DownloadTask.java
@@ -12,16 +12,16 @@ public class DownloadTask extends DefaultTask {
             System.err.println("No crowdin project name given, nothing downloaded");
             return;
         }
-        String[] args = new String[ (parms.getVerbose() ? 4 : 3) ];
+        String[] args = new String[ (parms.getVerbose().get() ? 4 : 3) ];
         int argc = 0;
-        if (parms.getVerbose()) {
+        if (parms.getVerbose().get()) {
             args[argc++] = "-v";
         }
-        String cpn = parms.getCrowdinProjectName();
-        String mpn = parms.getMinecraftProjectName();
+        String cpn = parms.getCrowdinProjectName().get();
+        String mpn = parms.getMinecraftProjectName().get();
         args[argc++] = cpn;
         args[argc++] = (mpn == null ? cpn : mpn);
-        args[argc++] = parms.getJsonSourceName();
+        args[argc++] = parms.getJsonSourceName().get();
 
         CrowdinTranslate.main(args);
         this.setDidWork(true);


### PR DESCRIPTION
Context: I'm making a plugin that applies a lot of my conventions to my mod projects, and in its current state I can't configure CrowdinTranslate via my own [lazily](https://docs.gradle.org/current/userguide/lazy_configuration.html) configured extension. 

Also `DownloadTask` using task inputs instead of a static reference to the extension is important for mulitproject builds.