### PR TITLE
Add custom fmj field parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,35 @@
+# gradle
+
 .gradle/
 build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+.vs/
+bin/
+.classpath
+.project
+
+# macos
+
+*.DS_Store
+
+# fabric
+
+run/
+remappedSrc/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In your build.gradle, at the very top (before `plugins`), add this:
 ```
 buildscript {
     dependencies {
-        classpath 'de.guntram.mcmod:crowdin-translate:1.2'
+        classpath 'de.guntram.mcmod:crowdin-translate:1.3+1.16'
     }
     repositories {
         maven {
@@ -53,7 +53,10 @@ buildscript {
 }
 ```
 
-and somewhere later (after plugins) add:
+(note that you can use this no matter which Minecraft version you're compiling
+for, even if the maven version number says 1.16).
+
+Then, somewhere later (after plugins) add:
 
 ```
 apply plugin: 'de.guntram.mcmod.crowdin-translate'
@@ -91,10 +94,14 @@ repositories {
 	}
 }
 dependencies {
-    modImplementation "de.guntram.mcmod:crowdin-translate:1.2"
-    include "de.guntram.mcmod:crowdin-translate:1.2"
+    modImplementation "de.guntram.mcmod:crowdin-translate:<version>"
+    include "de.guntram.mcmod:crowdin-translate:<version>"
 }
 ```
+
+where `version` is currently either `1.3+1.16` or `1.3+1.17-alpha20w49a`.
+(The `1.3+1.16` version actually works for all versions from 1.15.2 to 20w48a,
+20w49a introduced an incompatible change.)
 
 and this to your ClientModInitializer:
 
@@ -126,7 +133,35 @@ This will download the translations from
 `https://crowdin.com/project/projectname`
 to `assets/modid/lang`.
 
+### What if I have the translation files for several mods in the same crowdin
+project?
 
+Since version 1.3, you can override the translation source name that
+crowdin-translate checks for. So, if your mods are named foo, bar, and baz,
+you can have one single crowdin project that has them all, and have file names
+`foo.json`, `bar.json` and `thisisnotbaz.json` for your source.
+
+Assuming your crowdin project name is `allmymods`,
+adjust the above use cases like this:
+
+* manual usage:
+```
+java -jar crowdintranslate-<version>.jar allmymods foo foo
+java -jar crowdintranslate-<version>.jar allmymods bar bar
+java -jar crowdintranslate-<version>.jar allmymods baz thisisnotbaz
+```
+
+* usage in gradle: add a 'jsonSourceName' parameter
+
+```
+crowdintranslate.jsonSourceName = 'thisisnotbaz'
+```
+
+* usage in your `ClientModInitializer`: use the 3 argument call:
+
+```
+CrowdinTranslate.downloadTranslations("allmymods", "baz", "thisisnotbaz");
+```
 
 ### Getting started
 (this needs some redoing)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In your build.gradle, at the very top (before `plugins`), add this:
 ```
 buildscript {
     dependencies {
-        classpath 'de.guntram.mcmod:crowdin-translate:1.3+1.16'
+        classpath 'de.guntram.mcmod:crowdin-translate:1.3+1.17'
     }
     repositories {
         maven {
@@ -54,7 +54,7 @@ buildscript {
 ```
 
 (note that you can use this no matter which Minecraft version you're compiling
-for, even if the maven version number says 1.16).
+for, even if the maven version number says 1.17).
 
 Then, somewhere later (after plugins) add:
 
@@ -99,9 +99,9 @@ dependencies {
 }
 ```
 
-where `version` is currently either `1.3+1.16` or `1.3+1.17-alpha20w49a`.
+where `version` is currently either `1.3+1.16` or `1.3+1.17`.
 (The `1.3+1.16` version actually works for all versions from 1.15.2 to 20w48a,
-20w49a introduced an incompatible change.)
+20w49a introduced an incompatible change. 1.3+1.17 works from 1.17 on.)
 
 and this to your ClientModInitializer:
 
@@ -161,19 +161,3 @@ crowdintranslate.jsonSourceName = 'thisisnotbaz'
 ```
 CrowdinTranslate.downloadTranslations("allmymods", "baz", "thisisnotbaz");
 ```
-
-### Getting started
-(this needs some redoing)
-- Create an account on CrowdIn (https://crowdin.com)
-- Optional but recommended: apply for a open source membership so you can start multiple projects, for free
-- Create a project. This will ask for a project name, and a project address. 
-If possible, select your address so the identifier matches your mod id
-(the mod `foobar` should have `https://crowdin.com/project/foobar`).
-- Switch the source language from English to English, United States. This is not
-100% neccesary, but will make things easier, especially if your original json
-file is named `en_us.json`.
-- Add the target languages you want to use. (In a future version of CrowdinTranslate,
-there will be an easy way to consistently set the languages for a collection 
-of mods)
-- Once your project is created, upload your en_us.json. Then, do some translations,
-or get people to do that for you.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ This will download the translations from
 `https://crowdin.com/project/projectname`
 to `assets/modid/lang`.
 
-### What if I have the translation files for several mods in the same crowdin
-project?
+### What if I have the translation files for several mods in the same crowdin project?
 
 Since version 1.3, you can override the translation source name that
 crowdin-translate checks for. So, if your mods are named foo, bar, and baz,

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In your build.gradle, at the very top (before `plugins`), add this:
 ```
 buildscript {
     dependencies {
-        classpath 'de.guntram.mcmod:crowdin-translate:1.3+1.17'
+        classpath 'de.guntram.mcmod:crowdin-translate:1.5+1.21'
     }
     repositories {
         maven {
@@ -52,9 +52,6 @@ buildscript {
     }
 }
 ```
-
-(note that you can use this no matter which Minecraft version you're compiling
-for, even if the maven version number says 1.17).
 
 Then, somewhere later (after plugins) add:
 
@@ -94,14 +91,10 @@ repositories {
 	}
 }
 dependencies {
-    modImplementation "de.guntram.mcmod:crowdin-translate:<version>"
-    include "de.guntram.mcmod:crowdin-translate:<version>"
+    modImplementation "de.guntram.mcmod:crowdin-translate:1.5+1.21"
+    include "de.guntram.mcmod:crowdin-translate:1.5+1.21"
 }
 ```
-
-where `version` is currently either `1.3+1.16` or `1.3+1.17`.
-(The `1.3+1.16` version actually works for all versions from 1.15.2 to 20w48a,
-20w49a introduced an incompatible change. 1.3+1.17 works from 1.17 on.)
 
 and this to your ClientModInitializer:
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.19-pre2"
+version = "1.4+1.19"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json"
@@ -26,9 +26,9 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.19-pre2"
-    mappings "net.fabricmc:yarn:1.19-pre2+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.6"
+    minecraft "com.mojang:minecraft:1.19"
+    mappings "net.fabricmc:yarn:1.19+build.2:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.7"
     modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.53.3+1.19")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.19.3-alpha22w45a"
+version = "1.4+1.19.3"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json"
@@ -26,10 +26,10 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:22w45a"
-    mappings "net.fabricmc:yarn:22w45a+build.10:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.10"
-    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.66.1+1.19.3")
+    minecraft "com.mojang:minecraft:1.19.3"
+    mappings "net.fabricmc:yarn:1.19.3+build.2:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.11"
+    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.68.1+1.19.3")
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 archivesBaseName = "crowdin-translate"
-version = "1.3-pre1-hugman"
+version = "1.3+1.17-alpha20w49a"
 
 minecraft {
 	refmapName = "crowdin-translate-refmap.json";
@@ -31,9 +31,9 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft  "com.mojang:minecraft:1.15.2"
-    mappings   "net.fabricmc:yarn:1.15.2+build.7:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.7.2+build.174"
+    minecraft  "com.mojang:minecraft:20w49a"
+    mappings   "net.fabricmc:yarn:20w49a+build.5:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.10.8"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.18-pre5"
+version = "1.4+22w03a"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json";
@@ -28,16 +28,15 @@ processResources {
 dependencies {
     minecraft "com.mojang:minecraft:1.18-pre5"
     mappings "net.fabricmc:yarn:1.18-pre5+build.4:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.12.5"
+    modImplementation "net.fabricmc:fabric-loader:0.12.12"
 }
 
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 // if it is present.
 // If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+java {
+    withSourcesJar()
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.3+1.17-pre5"
+version = "1.3+1.17-pre5b"
 
 minecraft {
     refmapName = "crowdin-translate-refmap.json";

--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,34 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+    id 'fabric-loom' version '0.7-SNAPSHOT'
     id 'java-gradle-plugin'
+    id 'maven-publish'
 }
 
-apply plugin: 'maven'
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 16
+targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.3+1.17-alpha20w49a"
+version = "1.3+1.17-pre5"
 
 minecraft {
-	refmapName = "crowdin-translate-refmap.json";
+    refmapName = "crowdin-translate-refmap.json";
 }
 
 processResources {
-	inputs.property "version", project.version
+    inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.version
-	}
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
-	}
+    filesMatching("fabric.mod.json") {
+        expand "version": project.version
+    }
 }
 
 // These are, actually, not even used in this project.
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft  "com.mojang:minecraft:20w49a"
-    mappings   "net.fabricmc:yarn:20w49a+build.5:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.10.8"
+    minecraft  "com.mojang:minecraft:1.17-pre5"
+    mappings   "net.fabricmc:yarn:1.17-pre5+build.1:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.11.3"
 }
 
 
@@ -41,12 +36,12 @@ dependencies {
 // if it is present.
 // If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = 'sources'
-	from sourceSets.main.allSource
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
 jar {
-	from "LICENSE"
+    from "LICENSE"
     manifest {
         attributes(
             'Main-Class': 'de.guntram.mcmod.crowdintranslate.CrowdinTranslate'
@@ -65,10 +60,26 @@ gradlePlugin {
 }
 
 group = "de.guntram.mcmod"
+publishing {
+    publications {
+	mavenJava(MavenPublication) {
+	    artifact(remapJar) {
+		builtBy remapJar
+	    }
+	}
+    }
+    repositories {
+        maven {
+            url = "file://tmp/mymavenrepo"
+        }
+    }
+}
+
+/*
 uploadArchives {
     repositories {
         mavenDeployer {
-	        repository(url: "file://localhost/tmp/mymavenrepo")
+            repository(url: "file://localhost/tmp/mymavenrepo")
         }
     }
 }
@@ -76,3 +87,4 @@ uploadArchives {
 task publish(dependsOn: uploadArchives, type: Exec) {
     commandLine "rsync", "-av", "/tmp/mymavenrepo/", "maven@minecraft.guntram.de:/var/www/html/maven/"
 }
+*/

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.18-pre5"
+version = "1.4+1.18"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json";
@@ -26,9 +26,9 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.18-pre5"
-    mappings "net.fabricmc:yarn:1.18-pre5+build.4:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.12.5"
+    minecraft "com.mojang:minecraft:1.18"
+    mappings "net.fabricmc:yarn:1.18+build.1:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.12.8"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.7-SNAPSHOT'
+    id 'fabric-loom' version '0.8-SNAPSHOT'
     id 'java-gradle-plugin'
     id 'maven-publish'
 }
@@ -8,7 +8,7 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.3+1.17-pre5b"
+version = "1.3+1.17"
 
 minecraft {
     refmapName = "crowdin-translate-refmap.json";
@@ -26,8 +26,8 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft  "com.mojang:minecraft:1.17-pre5"
-    mappings   "net.fabricmc:yarn:1.17-pre5+build.1:v2"
+    minecraft  "com.mojang:minecraft:1.17"
+    mappings   "net.fabricmc:yarn:1.17+build.1:v2"
     modImplementation "net.fabricmc:fabric-loader:0.11.3"
 }
 
@@ -47,7 +47,6 @@ jar {
             'Main-Class': 'de.guntram.mcmod.crowdintranslate.CrowdinTranslate'
         )
     }
-    
 }
 
 gradlePlugin {
@@ -64,7 +63,7 @@ publishing {
     publications {
 	mavenJava(MavenPublication) {
 	    artifact(remapJar) {
-		builtBy remapJar
+		// builtBy remapJar
 	    }
 	}
     }
@@ -75,16 +74,6 @@ publishing {
     }
 }
 
-/*
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: "file://localhost/tmp/mymavenrepo")
-        }
-    }
-}
-
-task publish(dependsOn: uploadArchives, type: Exec) {
+task mypublish(dependsOn: publish, type: Exec) {
     commandLine "rsync", "-av", "/tmp/mymavenrepo/", "maven@minecraft.guntram.de:/var/www/html/maven/"
 }
-*/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.8-SNAPSHOT'
+    id 'fabric-loom' version '0.10-SNAPSHOT'
     id 'java-gradle-plugin'
     id 'maven-publish'
 }
@@ -8,10 +8,10 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.3+1.17"
+version = "1.4+1.18-pre1"
 
-minecraft {
-    refmapName = "crowdin-translate-refmap.json";
+loom {
+    mixin.defaultRefmapName = "crowdin-translate-refmap.json";
 }
 
 processResources {
@@ -26,9 +26,9 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft  "com.mojang:minecraft:1.17"
-    mappings   "net.fabricmc:yarn:1.17+build.1:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.11.3"
+    minecraft "com.mojang:minecraft:1.18-pre1"
+    mappings "net.fabricmc:yarn:1.18-pre1+build.14:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.12.5"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 16
 targetCompatibility = 16
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.18-pre1"
+version = "1.4+1.18-pre5"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json";
@@ -26,8 +26,8 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.18-pre1"
-    mappings "net.fabricmc:yarn:1.18-pre1+build.14:v2"
+    minecraft "com.mojang:minecraft:1.18-pre5"
+    mappings "net.fabricmc:yarn:1.18-pre5+build.4:v2"
     modImplementation "net.fabricmc:fabric-loader:0.12.5"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.18.2"
+version = "1.4+1.19-pre2"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json"
@@ -26,10 +26,10 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.18.2"
-    mappings "net.fabricmc:yarn:1.18.2+build.2:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.13.3"
-    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.47.10+1.18.2")
+    minecraft "com.mojang:minecraft:1.19-pre2"
+    mappings "net.fabricmc:yarn:1.19-pre2+build.1:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.6"
+    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.53.3+1.19")
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,17 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.11.+'
     id 'java-gradle-plugin'
     id 'maven-publish'
 }
 
-sourceCompatibility = 16
-targetCompatibility = 16
+sourceCompatibility = 17
+targetCompatibility = 17
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+22w03a"
+version = "1.4+1.18.2"
 
 loom {
-    mixin.defaultRefmapName = "crowdin-translate-refmap.json";
+    mixin.defaultRefmapName = "crowdin-translate-refmap.json"
 }
 
 processResources {
@@ -26,9 +26,10 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.18-pre5"
-    mappings "net.fabricmc:yarn:1.18-pre5+build.4:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.12.12"
+    minecraft "com.mojang:minecraft:1.18.2"
+    mappings "net.fabricmc:yarn:1.18.2+build.2:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.13.3"
+    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.47.10+1.18.2")
 }
 
 
@@ -60,11 +61,9 @@ gradlePlugin {
 group = "de.guntram.mcmod"
 publishing {
     publications {
-	mavenJava(MavenPublication) {
-	    artifact(remapJar) {
-		// builtBy remapJar
-	    }
-	}
+        mavenJava(MavenPublication) {
+            from components.java
+        }
     }
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 17
 targetCompatibility = 17
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.19"
+version = "1.4+1.19.3-alpha22w45a"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json"
@@ -26,10 +26,10 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.19"
-    mappings "net.fabricmc:yarn:1.19+build.2:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.7"
-    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.53.3+1.19")
+    minecraft "com.mojang:minecraft:22w45a"
+    mappings "net.fabricmc:yarn:22w45a+build.10:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.10"
+    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.66.1+1.19.3")
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'fabric-loom' version '0.11.+'
+    id 'fabric-loom' version '1.6.+'
     id 'java-gradle-plugin'
     id 'maven-publish'
 }
 
-sourceCompatibility = 17
-targetCompatibility = 17
+sourceCompatibility = 21
+targetCompatibility = 21
 
 archivesBaseName = "crowdin-translate"
-version = "1.4+1.19.3"
+version = "1.5+1.21"
 
 loom {
     mixin.defaultRefmapName = "crowdin-translate-refmap.json"
@@ -26,10 +26,10 @@ processResources {
 // They are only included to make loom happy.
 // Use old versions intentionally to make this work with a broad range of MCs.
 dependencies {
-    minecraft "com.mojang:minecraft:1.19.3"
-    mappings "net.fabricmc:yarn:1.19.3+build.2:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.11"
-    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.68.1+1.19.3")
+    minecraft "com.mojang:minecraft:1.21"
+    mappings "net.fabricmc:yarn:1.21+build.2"
+    modImplementation "net.fabricmc:fabric-loader:0.15.11"
+    modRuntimeOnly fabricApi.module("fabric-resource-loader-v0", "0.100.1+1.21")
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2G

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,5 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+rootProject.name = 'crowdin-translate'

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CTResourcePack.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CTResourcePack.java
@@ -51,7 +51,7 @@ public class CTResourcePack implements ResourcePack
     }
 
     @Override
-    public Collection<Identifier> findResources(ResourceType type, String namespace, String prefix, int maxDepth, Predicate<String> pathFilter)
+    public Collection<Identifier> findResources(ResourceType type, String namespace, String prefix, Predicate<Identifier> pathFilter)
     {
         if (type == ResourceType.SERVER_DATA) return Collections.emptyList();
         String start = CrowdinTranslate.getRootDir()+"/assets/" + namespace + "/" + prefix;

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CTResourcePack.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CTResourcePack.java
@@ -5,12 +5,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import net.minecraft.resource.InputSupplier;
-import net.minecraft.resource.ResourcePack;
-import net.minecraft.resource.ResourceType;
+
+import net.minecraft.resource.*;
 import net.minecraft.resource.metadata.ResourceMetadataReader;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import org.slf4j.Logger;
 
@@ -89,19 +88,19 @@ public class CTResourcePack implements ResourcePack
     }
 
     @Override
+    public ResourcePackInfo getInfo() {
+        return new ResourcePackInfo("CrowdinTranslate internal Resource Pack", Text.of("CrowdinTranslate internal Resource Pack"), ResourcePackSource.BUILTIN, Optional.empty());
+    }
+
+    /*@Override
     public String getName()
     {
         return "CrowdinTranslate internal Resource Pack";
-    }
+    }*/
 
     @Override
     public void close()
     {
-    }
-    
-    @Override
-    public boolean isAlwaysStable() {
-        return true;
     }
 
     private static Identifier fromPath(String path)
@@ -109,6 +108,6 @@ public class CTResourcePack implements ResourcePack
         if (path.startsWith("assets/"))
             path = path.substring("assets/".length());
         String[] split = path.split("/", 2);
-        return new Identifier(split[0], split[1]);
+        return Identifier.of(split[0], split[1]);
     }
 }

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/ClientInit.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/ClientInit.java
@@ -1,0 +1,103 @@
+package de.guntram.mcmod.crowdintranslate;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.CustomValue;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static de.guntram.mcmod.crowdintranslate.ClientInit.Keys.*;
+import static de.guntram.mcmod.crowdintranslate.CrowdinTranslate.*;
+import static net.fabricmc.loader.api.metadata.CustomValue.CvType.*;
+
+public class ClientInit implements ClientModInitializer {
+    private static String getRequiredString(CustomValue.CvObject object, String key, String modId) {
+        return getValue(object, key, STRING, CustomValue::getAsString, modId, true).orElse(null);
+    }
+
+    private static <T> Optional<T> getOptionalValue(
+        CustomValue.CvObject object, String key,
+        CustomValue.CvType type, Function<CustomValue, T> getter,
+        String modId
+    ) {
+        return getValue(object, key, type, getter, modId, false);
+    }
+
+    private static <T> Optional<T> getValue(
+        CustomValue.CvObject object, String key,
+        CustomValue.CvType type, Function<CustomValue, T> getter,
+        String modId, boolean logMissing
+    ) {
+        final var value = object.get(key);
+        if (value == null) {
+            if (logMissing) LOGGER.error(
+                "Missing \"{}\" key in object for \"" + NAME + "\" entrypoint in " +
+                    "fabric.mod.json of mod: {}",
+                key, modId
+            );
+
+            return Optional.empty();
+        } else {
+            final var valueType = value.getType();
+            if (valueType == type) return Optional.of(getter.apply(value));
+            else {
+                LOGGER.error(
+                    "Invalid type for \"{}\" key in object for \"" + NAME + "\" entrypoint in " +
+                        "fabric.mod.json of mod: {}\nExpected {}; found {}",
+                    key, modId, type, valueType
+                );
+
+                return Optional.empty();
+            }
+        }
+    }
+
+    @Override
+    public void onInitializeClient() {
+        for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
+            final var metadata = container.getMetadata();
+            final var customValue = metadata.getCustomValue(NAME);
+            if (customValue == null) continue;
+
+            final var type = customValue.getType();
+            final String modId = metadata.getId();
+            switch (type) {
+                case BOOLEAN -> { if (customValue.getAsBoolean()) downloadTranslations(modId); }
+                case STRING -> downloadTranslations(customValue.getAsString());
+                case OBJECT -> {
+                    final var object = customValue.getAsObject();
+
+                    final var crowdinProjectName = getRequiredString(object, CROWDIN_PROJECT_NAME, modId);
+                    if (crowdinProjectName == null) return;
+
+                    final var minecraftProjectName = getRequiredString(object, MINECRAFT_PROJECT_NAME, modId);
+                    if (minecraftProjectName == null) return;
+
+                    final var verbose =
+                        getOptionalValue(object, VERBOSE, BOOLEAN, CustomValue::getAsBoolean, modId)
+                            .orElse(false);
+
+                    final var sourcefileOverride =
+                        getOptionalValue(object, SOURCE_FILE_OVERRIDE, STRING, CustomValue::getAsString, modId)
+                            .orElse(null);
+
+                    downloadTranslations(crowdinProjectName, minecraftProjectName, sourcefileOverride, verbose);
+                }
+                default -> LOGGER.error(
+                    "Invalid type for \"" + NAME + "\" entrypoint in " +
+                        "fabric.mod.json of mod: {}\nExpected {}, {}, or {}; found {}",
+                    modId, BOOLEAN, STRING, OBJECT, type
+                );
+            }
+        }
+    }
+
+    public interface Keys {
+        String CROWDIN_PROJECT_NAME = "crowdinProjectName";
+        String MINECRAFT_PROJECT_NAME = "minecraftProjectName";
+        String SOURCE_FILE_OVERRIDE = "sourceFileOverride";
+        String VERBOSE = "verbose";
+    }
+}

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -113,6 +113,7 @@ public class CrowdinTranslate extends Thread {
         add("lt_lt", "lt");
         add("lv_lv", "lv");
         //add("lzh", "lzh");			// Classical Chinese
+        add("mi_NZ", "mi");
         add("mk_mk", "mk");
         add("mn_mn", "mn");
         add("ms_my", "ms");

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -242,6 +242,8 @@ public class CrowdinTranslate extends Thread {
             stream.write(buffer);
         } catch (IOException ex) {
             System.err.println("failed to write "+filename);
+            System.err.println("absolute path is "+file.getAbsolutePath());
+            ex.printStackTrace(System.err);
         }
     }
     

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -75,6 +75,10 @@ public class CrowdinTranslate extends Thread {
         downloadTranslations(crowdinProjectName, minecraftProjectName, null, verbose);
     }
 
+    public static void downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourcefileOverride) {
+        downloadTranslations(crowdinProjectName, minecraftProjectName, sourcefileOverride, false);
+    }
+
     public static void downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourcefileOverride, boolean verbose) {
         
         registeredMods.add(minecraftProjectName);

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -61,7 +61,9 @@ public class CrowdinTranslate extends Thread {
         add("en_ud", "en-UD,en-GB,en-US");
         add("en_us", "en-US");
         //add("enp", "enp");			// Anglish
-        //add("enws", "enws");			// Shakespearean English
+        add("en_ws", "en-WS");
+        add("en_pt", "en-PT");
+        add("en_ud", "en-UD");
         add("eo_uy", "eo");
         add("es_ar", "es-AR,es-ES");
         add("es_cl", "es-CL,es-ES");
@@ -119,7 +121,7 @@ public class CrowdinTranslate extends Thread {
         add("nl_be", "nl-BE,nl");
         add("nl_nl", "nl");
         add("nn_no", "nn-NO,no");
-        add("no_no‌", "no");
+        add("no_no", "no,nb");
         add("oc_fr", "oc");
         //add("ovd", "ovd");			// Elfdalian
         add("pl_pl", "pl");

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -62,7 +62,7 @@ public class CrowdinTranslate extends Thread {
         add("en_us", "en-US");
         //add("enp", "enp");			// Anglish
         add("en_ws", "en-WS");
-        add("en_pt", "en-PT");
+        add("en_7s", "en-PT");
         add("en_ud", "en-UD");
         add("eo_uy", "eo");
         add("es_ar", "es-AR,es-ES");

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -28,34 +28,124 @@ public class CrowdinTranslate extends Thread {
         mcCodetoCrowdinCode = new HashMap<>();
         registeredMods = new HashSet<>();
 
+        add("af_za", "af");
+        add("ar_sa", "ar");
+        add("ast_es", "ast");
+        add("az_az", "az");
+        add("ba_ru", "ba");
+        //add("bar", "bar");			// Bavaria
+        add("be_by", "be");
+        add("bg_bg", "bg");
+        add("br_fr", "br-FR");
+        //add("brb", "brb");			// Brabantian
+        add("bs_ba", "bs");
+        add("ca_es", "ca");
         add("cs_cz", "cs");
+        add("cy_gb", "cy");
+        add("da_dk", "da");
+        add("de_at", "de-AT");
+        add("de_ch", "de-CH");
         add("de_de", "de");
         add("el_gr", "el");
-        add("es_ar", "es-ES");
-        add("es_cl", "es-ES");
-        add("es_ec", "es-ES");
+        add("en_au", "de-AT");
+        add("en_ca", "en-CA");
+        add("en_gb", "en-GB");
+        add("en_nz", "en-NZ");
+        add("en_pt", "en-PT");
+        add("en_ud", "en-UD");
+        add("en_us", "en-US");
+        //add("enp", "enp");			// Anglish
+        //add("enws", "enws");			// Shakespearean English
+        add("eo_uy", "eo");
+        add("es_ar", "es-AR");
+        add("es_cl", "es-CL");
+        add("es_ec", "es-EC");
         add("es_es", "es-ES");
-        add("es_mx", "es-ES");
-        add("es_uy", "es-ES");
-        add("es_ve", "es-ES");
+        add("es_mx", "es-MX");
+        add("es_uy", "es-UY");
+        add("es_ve", "es-VE");
+        //add("esan", "esan");			// Andalusian
         add("et_ee", "et");
+        add("eu_es", "eu");
+        add("fa_ir", "fa");
         add("fi_fi", "fi");
+        add("fil_ph", "fil");
+        add("fo_fo", "fo");
+        add("fr_ca", "fr-CA");
         add("fr_fr", "fr");
+        add("fra_de", "fra-DE");
+        add("fy_nl", "fy-NL");
+        add("ga_ie", "ga-IE");
+        add("gd_gb", "gd");
+        add("gl_es", "gl");
+        add("haw_us", "haw");
         add("he_il", "he");
+        add("hi_in", "hi");
+        add("hr_hr", "hr");
+        add("hu_hu", "hu");
+        add("hy_am", "hy-AM");
+        add("id_id", "id");
+        add("ig_ng", "ig");
+        add("io_en", "ido");
+        add("is_is", "is");
+        //add("isv", "isv");			// Interslavic
         add("it_it", "it");
         add("ja_jp", "ja");
+        add("jbo_en", "jbo");
+        add("ka_ge", "ka");
+        add("kk_kz", "kk");
+        add("kn_in", "kn");
         add("ko_kr", "ko");
+        //add("ksh", "ksh");			// Ripuarian
+        add("kw_gb", "kw");
+        add("la_la", "la-LA");
+        add("lb_lu", "lb");
+        add("li_li", "li");
+        add("lol_us", "lol");
+        add("lt_lt", "lt");
+        add("lv_lv", "lv");
+        //add("lzh", "lzh");			// Classical Chinese
+        add("mk_mk", "mk");
+        add("mn_mn", "mn");
+        add("ms_my", "ms");
+        add("mt_mt", "mt");
+        add("nds_de", "nds");
+        add("nl_be", "nl-BE");
         add("nl_nl", "nl");
-        add("no_no", "no");
+        add("nn_no", "nn-NO");
+        add("no_no‌", "no");
+        add("oc_fr", "oc");
+        //add("ovd", "ovd");			// Elfdalian
         add("pl_pl", "pl");
-        add("pt_br", "pt-PT");
+        add("pt_br", "pt-BR");
         add("pt_pt", "pt-PT");
+        add("qya_aa", "qya-AA");
         add("ro_ro", "ro");
+        //add("rpr", "rpr");			// Russian (pre-revolutionary)
         add("ru_ru", "ru");
+        add("se_no", "se");
+        add("sk_sk", "sk");
+        add("sl_si", "sl");
+        add("so_so", "so");
+        add("sq_al", "sq");
         add("sr_sp", "sr");
         add("sv_se", "sv-SE");
+        //add("sxu", "sxu");			// Upper Saxon German
+        //add("szl", "szl");			// Silesian
+        add("ta_in", "ta");
+        add("th_th", "th");
+        add("tl_ph", "tl");
+        add("tlh_aa", "tlh-AA");
         add("tr_tr", "tr");
+        add("tt_ru", "tt-RU");
+        add("uk_ua", "uk");
+        add("val_es", "val-ES");
+        add("vec_it", "vec");
+        add("vi_vn", "vi");
+        add("yi_de", "yi");
+        add("yo_ng", "yo");
         add("zh_cn", "zh-CN");
+        add("zh_hk", "zh-HK");
         add("zh_tw", "zh-TW");
     }
     

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/CrowdinTranslate.java
@@ -1,5 +1,8 @@
 package de.guntram.mcmod.crowdintranslate;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -21,7 +24,9 @@ import java.util.zip.ZipInputStream;
 
 
 public class CrowdinTranslate extends Thread {
-    
+    public static final String NAME = "crowdin-translate";
+    public static final Logger LOGGER = LogManager.getLogger();
+
     private static final Map<String, String> mcCodetoCrowdinCode;
     /* The directory to download to. This is used in the mod; main will overwrite this.  */
     private static String rootDir = "ModTranslations";
@@ -174,11 +179,11 @@ public class CrowdinTranslate extends Thread {
         downloadTranslations(crowdinProjectName, minecraftProjectName, null, verbose);
     }
 
-    public static void downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourcefileOverride) {
-        downloadTranslations(crowdinProjectName, minecraftProjectName, sourcefileOverride, false);
+    public static void downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourceFileOverride) {
+        downloadTranslations(crowdinProjectName, minecraftProjectName, sourceFileOverride, false);
     }
 
-    public static void downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourcefileOverride, boolean verbose) {
+    public static void downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourceFileOverride, boolean verbose) {
         
         registeredMods.add(minecraftProjectName);
         if (thisIsAMod && ( !downloadsAllowed() || projectDownloadedRecently(minecraftProjectName))) {
@@ -188,8 +193,8 @@ public class CrowdinTranslate extends Thread {
         if (verbose) {
             runner.setVerbose();
         }
-        if (sourcefileOverride != null) {
-            runner.setSourceFileOverride(sourcefileOverride);
+        if (sourceFileOverride != null) {
+            runner.setSourceFileOverride(sourceFileOverride);
         }
         runner.start();
         if (!thisIsAMod) {

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/DownloadTask.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/GradlePlugin/DownloadTask.java
@@ -1,10 +1,10 @@
 package de.guntram.mcmod.crowdintranslate.GradlePlugin;
 
 import de.guntram.mcmod.crowdintranslate.CrowdinTranslate;
-import org.gradle.api.internal.AbstractTask;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
-public class DownloadTask extends AbstractTask {
+public class DownloadTask extends DefaultTask {
     @TaskAction
     public void action() {
         CrowdinTranslateParameters parms = CrowdinTranslatePlugin.parameters;

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
@@ -1,62 +1,36 @@
 package de.guntram.mcmod.crowdintranslate.mixins;
 
 import de.guntram.mcmod.crowdintranslate.CTResourcePack;
+
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import net.minecraft.resource.*;
-import net.minecraft.util.Unit;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(ReloadableResourceManagerImpl.class)
 
-public abstract class ReloadableResourceManagerImplMixin implements ReloadableResourceManager
+public abstract class ReloadableResourceManagerImplMixin
 {
     @Shadow
     @Final
     private ResourceType type;
 
-    @Shadow
-    public abstract void addPack(ResourcePack resourcePack);
-
-    // Compatibility with 22w03a+ using slf4j logger instead of log4j
-    @Inject(
+    @ModifyArg(
             method = "reload",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lorg/slf4j/Logger;isDebugEnabled()Z",
-                    shift = At.Shift.BEFORE
-            ),
-            require = 0
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/resource/LifecycledResourceManagerImpl;<init>(Lnet/minecraft/resource/ResourceType;Ljava/util/List;)V"),
+            index = 1
     )
-    private void onPostReload(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
+    private List<ResourcePack> onPostReload(List<ResourcePack> packs)
     {
         if (this.type != ResourceType.CLIENT_RESOURCES)
-            return;
+            return packs;
 
-        this.addPack(new CTResourcePack());
-    }
-
-    // Compatibility with 1.18.1 and below using log4j
-    @Inject(
-            method = "reload",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
-                    shift = At.Shift.BEFORE
-            ),
-            require = 0
-    )
-    private void onPostReloadLegacy(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
-    {
-        if (this.type != ResourceType.CLIENT_RESOURCES)
-            return;
-
-        this.addPack(new CTResourcePack());
+        List<ResourcePack> list = new ArrayList<>(packs);
+        list.add(new CTResourcePack());
+        return list;
     }
 }

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
@@ -28,7 +28,7 @@ public abstract class ReloadableResourceManagerImplMixin implements ReloadableRe
             method = "beginMonitoredReload",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/resource/ReloadableResourceManagerImpl;beginReloadInner(Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Ljava/util/List;Ljava/util/concurrent/CompletableFuture;)Lnet/minecraft/resource/ResourceReloadMonitor;",
+                    target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
                     shift = At.Shift.BEFORE
             )
     )

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
@@ -25,14 +25,14 @@ public abstract class ReloadableResourceManagerImplMixin implements ReloadableRe
     public abstract void addPack(ResourcePack resourcePack);
 
     @Inject(
-            method = "beginMonitoredReload",
+            method = "reload",
             at = @At(
                     value = "INVOKE",
                     target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
                     shift = At.Shift.BEFORE
             )
     )
-    private void onPostReload(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReloadMonitor> cir)
+    private void onPostReload(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
     {
         if (this.type != ResourceType.CLIENT_RESOURCES)
             return;

--- a/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/de/guntram/mcmod/crowdintranslate/mixins/ReloadableResourceManagerImplMixin.java
@@ -24,20 +24,39 @@ public abstract class ReloadableResourceManagerImplMixin implements ReloadableRe
     @Shadow
     public abstract void addPack(ResourcePack resourcePack);
 
+    // Compatibility with 22w03a+ using slf4j logger instead of log4j
     @Inject(
             method = "reload",
             at = @At(
                     value = "INVOKE",
-                    target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
+                    target = "Lorg/slf4j/Logger;isDebugEnabled()Z",
                     shift = At.Shift.BEFORE
-            )
+            ),
+            require = 0
     )
     private void onPostReload(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
     {
         if (this.type != ResourceType.CLIENT_RESOURCES)
             return;
 
-        System.out.println("Inject generated resource packs.");
+        this.addPack(new CTResourcePack());
+    }
+
+    // Compatibility with 1.18.1 and below using log4j
+    @Inject(
+            method = "reload",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lorg/apache/logging/log4j/Logger;isDebugEnabled()Z",
+                    shift = At.Shift.BEFORE
+            ),
+            require = 0
+    )
+    private void onPostReloadLegacy(Executor prepareExecutor, Executor applyExecutor, CompletableFuture<Unit> initialStage, List<ResourcePack> packs, CallbackInfoReturnable<ResourceReload> cir)
+    {
+        if (this.type != ResourceType.CLIENT_RESOURCES)
+            return;
+
         this.addPack(new CTResourcePack());
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,7 @@
         "mixins.crowdintranslate.json"
     ],
     "depends": {
-      "fabric": "*"
+      "fabric-resource-loader-v0": "*"
     },
     "name": "CrowdinTranslate",
     "description": "Downloads translations (xx_xx.json) files from Crowdin",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,7 +6,11 @@
     },
     "custom": {
         "ThanksGoTo": "LambdAurora for letting me use the virtual resource pack loader",
-        "modmenu:api": true
+        "modmenu": {
+            "badges": [
+                "library"
+	    ]
+	}
     },
     "mixins": [
         "mixins.crowdintranslate.json"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,20 +3,22 @@
     "id": "crowdin-translate",
     "version": "${version}",
     "entrypoints": {
+        "client": [ "de.guntram.mcmod.crowdintranslate.ClientInit" ]
     },
     "custom": {
         "ThanksGoTo": "LambdAurora for letting me use the virtual resource pack loader",
         "modmenu": {
             "badges": [
                 "library"
-	    ]
-	}
+            ]
+        }
     },
     "mixins": [
         "mixins.crowdintranslate.json"
     ],
     "depends": {
-      "fabric-resource-loader-v0": "*"
+        "fabric-resource-loader-v0": "*",
+        "fabricloader": "*"
     },
     "name": "CrowdinTranslate",
     "description": "Downloads translations (xx_xx.json) files from Crowdin",


### PR DESCRIPTION
Based on #23 
Implements my suggestion here https://github.com/gbl/CrowdinTranslate/issues/20#issuecomment-2146411722
IMO if this is added the config added by #23 should be removed, as installing the mod would be 'enabling' it.
It only makes sense to  merge this if the mod is hosted on Modrinth+CurseForge, so users can install to 'enable'.

The fmj field has several forms:
- use mod id for Crowdin and Minecraft project names
```json
"custom": {
    "crowdin-translate": true
}
```
- use the string value for Crowdin and Minecraft project names
```json
"custom": {
    "crowdin-translate": "some-mod"
}
```
- specify all the params for `CrowdinTranslate#downloadTranslations(String crowdinProjectName, String minecraftProjectName, String sourceFileOverride, boolean verbose)`; `sourceFileOverride`, and `verbose` are optional
```json
"custom": {
    "crowdin-translate": {
      "crowdinProjectName": "some-other-mod",
      "minecraftProjectName": "some_other_mod",
      "sourceFileOverride": "thing.json",
      "verbose": true
    }
}
```